### PR TITLE
Add missing ez_setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,7 +9,7 @@ include blist/test/*.py
 include README.rst
 include LICENSE
 include prototype/blist.py
-include distribute_setup.py
+include ez_setup.py
 include speed_test.py
 include blist.rst
 include blist/blist.h


### PR DESCRIPTION
Missing ez_setup.py in blist 1.3.5 (on PyPI).
