### PR TITLE
replace import collections with collections.abc

### DIFF
--- a/blist/__init__.py
+++ b/blist/__init__.py
@@ -1,6 +1,6 @@
 __version__ = '1.3.6'
 from blist._blist import *
-import collections
+import collections.abc as collections
 if hasattr(collections, 'MutableSet'): # Only supported in Python 2.6+
     from blist._sortedlist import sortedlist, sortedset, weaksortedlist, weaksortedset
     from blist._sorteddict import sorteddict

--- a/blist/_btuple.py
+++ b/blist/_btuple.py
@@ -1,6 +1,6 @@
 from blist._blist import blist
 from ctypes import c_int
-import collections
+import collections.abc as collections
 class btuple(collections.Sequence):
     def __init__(self, seq=None):
         if isinstance(seq, btuple):

--- a/blist/_sorteddict.py
+++ b/blist/_sorteddict.py
@@ -1,5 +1,5 @@
 from blist._sortedlist import sortedset, ReprRecursion
-import collections, sys
+import collections.abc as collections, sys
 from blist._blist import blist
 
 class missingdict(dict):

--- a/blist/_sortedlist.py
+++ b/blist/_sortedlist.py
@@ -1,5 +1,5 @@
 from blist._blist import blist
-import collections, bisect, weakref, operator, itertools, sys, threading
+import collections.abc as collections, bisect, weakref, operator, itertools, sys, threading
 try: # pragma: no cover
     izip = itertools.izip
 except AttributeError: # pragma: no cover

--- a/blist/test/mapping_tests.py
+++ b/blist/test/mapping_tests.py
@@ -2,7 +2,7 @@
 
 # tests common to dict and UserDict
 import sys
-import collections
+import collections.abc as collections
 from blist.test import unittest
 try:
     from collections import UserDict # Python 3

--- a/blist/test/sortedlist_tests.py
+++ b/blist/test/sortedlist_tests.py
@@ -1,7 +1,7 @@
 # This file based loosely on Python's list_tests.py.
 
 import sys
-import collections, operator
+import collections.abc as collections, operator
 import gc
 import random
 import blist

--- a/blist/test/test_set.py
+++ b/blist/test/test_set.py
@@ -10,7 +10,7 @@ import pickle
 from random import randrange, shuffle
 import sys
 import warnings
-import collections
+import collections.abc as collections
 
 from blist.test import unittest
 from blist.test import test_support as support


### PR DESCRIPTION
replaced collections with collections.abc to be compatible with python 3.8