### PR TITLE
remove __setitem__ from sortedlist docs

### DIFF
--- a/doc/sortedlist.rst
+++ b/doc/sortedlist.rst
@@ -130,14 +130,6 @@ sortedlist
 
       :rtype: iterator
 
-   .. method:: L[i] = x
-
-      Replace the item at position *i* of *L* with *x*.
-
-      Requires |theta(log n)| operations in the worst case but only
-      |theta(1)| operations if the list's size has not been changed
-      recently.  Requires no comparisons in any case.
-
    .. method:: L[i:j] = iterable
 
       Replace the items at positions *i* through *j* with the contents


### PR DESCRIPTION
It's not available in the class in v1.3.6, which agrees with my impression that it's not meant to be. 

On the other hand, I can imagine you might have written an optimization of 
```
def __setitem__(L,i,x):
    del L[i]
    L.add(x)
    assert L[i] == x
```
And in fact I'd have used such a method, in a situation where the correct insertion position for `x` was earlier deduced for some other purpose (other than inserting `x`).