### PR TITLE
Support 3.9

### DIFF
--- a/blist/__init__.py
+++ b/blist/__init__.py
@@ -1,10 +1,24 @@
 __version__ = '1.3.6'
 from blist._blist import *
 import collections
-if hasattr(collections, 'MutableSet'): # Only supported in Python 2.6+
+from sys import version_info
+
+
+_pyvers = version_info.major * 1000 + version_info.minor * 10
+# Supported only in Python >= 2.6
+if _pyvers >= 2060:
     from blist._sortedlist import sortedlist, sortedset, weaksortedlist, weaksortedset
     from blist._sorteddict import sorteddict
     from blist._btuple import btuple
-    collections.MutableSequence.register(blist)
+    if _pyvers >= 3000:
+        # Python >= 3
+        # collections.MutableSequence works until 3.9 but emits DeprecationWarning
+        # This fixes the hard break on 3.9 and the warnings on earlier versions
+        import collections.abc
+        MutableSequence = collections.abc.MutableSequence
+    else:
+        # Python >= 2.6, < 3
+        MutableSequence = collections.MutableSequence
+    MutableSequence.register(blist)
     del _sortedlist, _sorteddict, _btuple
 del collections

--- a/blist/_btuple.py
+++ b/blist/_btuple.py
@@ -1,6 +1,15 @@
 from blist._blist import blist
 from ctypes import c_int
 import collections
+import sys
+
+
+_pyvers = sys.version_info.major * 1000 + sys.version_info.minor * 10
+
+if _pyvers >= 3000:
+    import collections.abc as collections
+
+
 class btuple(collections.Sequence):
     def __init__(self, seq=None):
         if isinstance(seq, btuple):

--- a/blist/_sorteddict.py
+++ b/blist/_sorteddict.py
@@ -2,6 +2,13 @@ from blist._sortedlist import sortedset, ReprRecursion
 import collections, sys
 from blist._blist import blist
 
+
+_pyvers = sys.version_info.major * 1000 + sys.version_info.minor * 10
+
+if _pyvers >= 3000:
+    import collections.abc as collections
+
+
 class missingdict(dict):
     def __missing__(self, key):
         return self._missing(key)

--- a/blist/_sortedlist.py
+++ b/blist/_sortedlist.py
@@ -8,18 +8,18 @@ except AttributeError: # pragma: no cover
 
 _pyvers = sys.version_info.major * 1000 + sys.version_info.minor * 10
 if _pyvers >= 3000:
-    from collections.abc import Set, Sequence
-else:
-    from collections import Set, Sequence
+    from collections import defaultdict
+    import collections.abc as collections
 
 
 __all__ = ['sortedlist', 'weaksortedlist', 'sortedset', 'weaksortedset']
+
 
 class ReprRecursion(object):
     local = threading.local()
     def __init__(self, ob):
         if not hasattr(self.local, 'repr_count'):
-            self.local.repr_count = collections.defaultdict(int)
+            self.local.repr_count = defaultdict(int)
         self.ob_id = id(ob)
         self.value = self.ob_id in self.local.repr_count
 
@@ -33,7 +33,7 @@ class ReprRecursion(object):
             del self.local.repr_count[self.ob_id]
         return False
 
-class _sortedbase(Sequence):
+class _sortedbase(collections.Sequence):
     def __init__(self, iterable=(), key=None):
         self._key = key
         if key is not None and not hasattr(key, '__call__'):
@@ -439,7 +439,7 @@ class _setmixin(object):
 
 def safe_cmp(f):
     def g(self, other):
-        if not isinstance(other, Set):
+        if not isinstance(other, collections.Set):
             raise TypeError("can only compare to a set")
         return f(self, other)
     return g

--- a/blist/_sortedlist.py
+++ b/blist/_sortedlist.py
@@ -420,11 +420,14 @@ class _setmixin(object):
     def __iter__(self):
         it = super(_setmixin, self).__iter__()
         while True:
-            item = next(it)
-            n = len(self)
-            yield item
-            if n != len(self):
-                raise RuntimeError('Set changed size during iteration')
+            try:
+                item = next(it)
+                n = len(self)
+                yield item
+                if n != len(self):
+                    raise RuntimeError('Set changed size during iteration')
+            except StopIteration:
+                return
 
 def safe_cmp(f):
     def g(self, other):

--- a/blist/_sortedlist.py
+++ b/blist/_sortedlist.py
@@ -5,6 +5,14 @@ try: # pragma: no cover
 except AttributeError: # pragma: no cover
     izip = zip
 
+
+_pyvers = sys.version_info.major * 1000 + sys.version_info.minor * 10
+if _pyvers >= 3000:
+    from collections.abc import Set, Sequence
+else:
+    from collections import Set, Sequence
+
+
 __all__ = ['sortedlist', 'weaksortedlist', 'sortedset', 'weaksortedset']
 
 class ReprRecursion(object):
@@ -25,7 +33,7 @@ class ReprRecursion(object):
             del self.local.repr_count[self.ob_id]
         return False
 
-class _sortedbase(collections.Sequence):
+class _sortedbase(Sequence):
     def __init__(self, iterable=(), key=None):
         self._key = key
         if key is not None and not hasattr(key, '__call__'):
@@ -431,7 +439,7 @@ class _setmixin(object):
 
 def safe_cmp(f):
     def g(self, other):
-        if not isinstance(other, collections.Set):
+        if not isinstance(other, Set):
             raise TypeError("can only compare to a set")
         return f(self, other)
     return g
@@ -479,7 +487,7 @@ class _setmixin2(collections.MutableSet):
         return self._from_iterable(other) - self
 
     def _make_set(self, iterable):
-        if isinstance(iterable, collections.Set):
+        if isinstance(iterable, Set):
             return iterable
         return self._from_iterable(iterable)
 

--- a/blist/pythoncapi_compat.h
+++ b/blist/pythoncapi_compat.h
@@ -1,0 +1,192 @@
+/* Header file providing new functions of the Python C API
+   for old Python versions.
+
+   File distributed under the MIT license.
+   Homepage: https://github.com/pythoncapi/pythoncapi_compat.
+*/
+
+#ifndef PYTHONCAPI_COMPAT
+#define PYTHONCAPI_COMPAT
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <Python.h>
+#include "frameobject.h"          // PyFrameObject
+
+
+// bpo-39573: Py_TYPE(), Py_REFCNT() and Py_SIZE() can no longer be used
+// as l-value in Python 3.10.
+#if PY_VERSION_HEX < 0x030900A4
+static inline void _Py_SET_REFCNT(PyObject *ob, Py_ssize_t refcnt)
+{
+    ob->ob_refcnt = refcnt;
+}
+#define Py_SET_REFCNT(ob, refcnt) _Py_SET_REFCNT((PyObject*)(ob), refcnt)
+
+
+static inline void
+_Py_SET_TYPE(PyObject *ob, PyTypeObject *type)
+{
+    ob->ob_type = type;
+}
+#define Py_SET_TYPE(ob, type) _Py_SET_TYPE((PyObject*)(ob), type)
+
+static inline void
+_Py_SET_SIZE(PyVarObject *ob, Py_ssize_t size)
+{
+    ob->ob_size = size;
+}
+#define Py_SET_SIZE(ob, size) _Py_SET_SIZE((PyVarObject*)(ob), size)
+
+#endif  // PY_VERSION_HEX < 0x030900A4
+
+
+#if PY_VERSION_HEX < 0x030900B1
+static inline PyCodeObject*
+PyFrame_GetCode(PyFrameObject *frame)
+{
+    assert(frame != NULL);
+    PyCodeObject *code = frame->f_code;
+    assert(code != NULL);
+    Py_INCREF(code);
+    return code;
+}
+#endif
+
+
+#if PY_VERSION_HEX < 0x030900B1
+static inline PyFrameObject*
+PyFrame_GetBack(PyFrameObject *frame)
+{
+    assert(frame != NULL);
+    PyFrameObject *back = frame->f_back;
+    Py_XINCREF(back);
+    return back;
+}
+#endif
+
+
+#if PY_VERSION_HEX < 0x030900A5
+static inline PyInterpreterState *
+PyThreadState_GetInterpreter(PyThreadState *tstate)
+{
+    assert(tstate != NULL);
+    return tstate->interp;
+}
+#endif
+
+
+#if PY_VERSION_HEX < 0x030900B1
+static inline PyFrameObject*
+PyThreadState_GetFrame(PyThreadState *tstate)
+{
+    assert(tstate != NULL);
+    PyFrameObject *frame = tstate->frame;
+    Py_XINCREF(frame);
+    return frame;
+}
+#endif
+
+
+#if PY_VERSION_HEX < 0x030900A5
+static inline PyInterpreterState *
+PyInterpreterState_Get(void)
+{
+    PyThreadState *tstate = PyThreadState_GET();
+    if (tstate == NULL) {
+        Py_FatalError("GIL released (tstate is NULL)");
+    }
+    PyInterpreterState *interp = tstate->interp;
+    if (interp == NULL) {
+        Py_FatalError("no current interpreter");
+    }
+    return interp;
+}
+#endif
+
+
+#if 0x030700A1 <= PY_VERSION_HEX && PY_VERSION_HEX < 0x030900A6
+static inline uint64_t
+PyThreadState_GetID(PyThreadState *tstate)
+{
+    assert(tstate != NULL);
+    return tstate->id;
+}
+#endif
+
+
+#if PY_VERSION_HEX < 0x030900A1
+static inline PyObject*
+PyObject_CallNoArgs(PyObject *func)
+{
+    return PyObject_CallFunctionObjArgs(func, NULL);
+}
+#endif
+
+
+#if PY_VERSION_HEX < 0x030900A4
+static inline PyObject*
+PyObject_CallOneArg(PyObject *func, PyObject *arg)
+{
+    return PyObject_CallFunctionObjArgs(func, arg, NULL);
+}
+#endif
+
+
+#if PY_VERSION_HEX < 0x030900A5
+static inline int
+PyModule_AddType(PyObject *module, PyTypeObject *type)
+{
+    if (PyType_Ready(type) < 0) {
+        return -1;
+    }
+
+    // inline _PyType_Name()
+    const char *name = type->tp_name;
+    assert(name != NULL);
+    const char *dot = strrchr(name, '.');
+    if (dot != NULL) {
+        name = dot + 1;
+    }
+
+    Py_INCREF(type);
+    if (PyModule_AddObject(module, name, (PyObject *)type) < 0) {
+        Py_DECREF(type);
+        return -1;
+    }
+
+    return 0;
+}
+#endif
+
+
+#if PY_VERSION_HEX < 0x030900A6
+static inline int
+PyObject_GC_IsTracked(PyObject* obj)
+{
+    return (PyObject_IS_GC(obj) && _PyObject_GC_IS_TRACKED(obj));
+}
+
+static inline int
+PyObject_GC_IsFinalized(PyObject *obj)
+{
+    return (PyObject_IS_GC(obj) && _PyGCHead_FINALIZED((PyGC_Head *)(obj)-1));
+}
+#endif  // PY_VERSION_HEX < 0x030900A6
+
+
+#if PY_VERSION_HEX < 0x030900A4
+static inline int
+_Py_IS_TYPE(const PyObject *ob, const PyTypeObject *type) {
+    return ob->ob_type == type;
+}
+#define Py_IS_TYPE(ob, type) _Py_IS_TYPE((const PyObject*)(ob), type)
+#endif
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // PYTHONCAPI_COMPAT

--- a/blist/test/sortedlist_tests.py
+++ b/blist/test/sortedlist_tests.py
@@ -8,6 +8,15 @@ import blist
 from blist.test import unittest
 from blist.test import list_tests, seq_tests
 
+_pyvers = sys.version_info.major * 1000 + sys.version_info.minor * 10
+
+# Supported only in Python >= 2.6
+if _pyvers >= 3000:
+    from collections.abc import Set
+else:
+    from collections import Set
+
+
 def CmpToKey(mycmp):
     'Convert a cmp= function into a key= function'
     class K(object):
@@ -185,7 +194,7 @@ class SortedBase(object):
     def test_order(self):
         stuff = [self.build_item(random.randrange(1000000))
                  for i in range(1000)]
-        if issubclass(self.type2test, collections.Set):
+        if issubclass(self.type2test, Set):
             stuff = set(stuff)
         sorted_stuff = list(sorted(stuff))
         u = self.type2test

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name='blist',
       ext_modules=[Extension('blist._blist', ['blist/_blist.c'],
                              define_macros=define_macros,
                              )],
-      packages=['blist'],
+      packages=['blist', 'blist.test'],
       provides = ['blist'],
       test_suite = "test_blist.test_suite",
       zip_safe = False, # zips are broken on cygwin for C extension modules


### PR DESCRIPTION
Much of this came from the conda-forge blist-feedstock patches once I stumbled across them, thanks to @h-vetinari for that

This addresses a handful of open issues, some of which have fixes in other trees and/or have open PRs here

Overlapping PRs: #92 , #91, #85 (I think #85 may break 2.x but I didn't look too thoroughly)
Issues that it *should* fix: #81 , #79, #90, 

Because there are so many overlapping PRs I don't expect you to sift through this- you may just want to close it. I'm going to keep my fork+branch and use that for now, I needed something for ppc64le system with Python3.9.5 which is how I ended up going down this road. I figured I might as well send what I have upstream (even if it's an amalgamation of things that already have PRs)

The summary:

* Fix import breakage on 3.9 as well as soft-fails (DeprecationWarning) on >3, <3.9 - applies to some tests, the package init and the _sortedlist module 
* Changes required for 3.9 due to PEP-0620 changes; taken from https://github.com/conda-forge/blist-feedstock
* Changes for PEP-479 from conda-forge blist-feedstock patches
* Remove unnecessary preprocessor macros, from conda-forge blist-feedstock patches

Thanks for this project, it's very nice having something as a drop-in replacement for `list` for cases where `numpy` arrays don't quite make sense